### PR TITLE
print() Python 2 compatibility.

### DIFF
--- a/octohub/__main__.py
+++ b/octohub/__main__.py
@@ -7,6 +7,7 @@
 # terms of the GNU General Public License as published by the Free Software
 # Foundation; either version 3 of the License, or (at your option) any later
 # version.
+from __future__ import print_function
 
 """
 OctoHub: GitHub API CLI

--- a/octohub/connection.py
+++ b/octohub/connection.py
@@ -6,6 +6,7 @@
 # terms of the GNU General Public License as published by the Free Software
 # Foundation; either version 3 of the License, or (at your option) any later
 # version.
+from __future__ import print_function
 
 import requests
 

--- a/octohub/contrib/gist/octohub-gist
+++ b/octohub/contrib/gist/octohub-gist
@@ -7,6 +7,7 @@
 # terms of the GNU General Public License as published by the Free Software
 # Foundation; either version 3 of the License, or (at your option) any later
 # version.
+from __future__ import print_function
 
 """
 OctoHub: Gist CLI

--- a/octohub/contrib/offline-issues/octohub-parse-issues
+++ b/octohub/contrib/offline-issues/octohub-parse-issues
@@ -7,6 +7,7 @@
 # terms of the GNU General Public License as published by the Free Software
 # Foundation; either version 3 of the License, or (at your option) any later
 # version.
+from __future__ import print_function
 
 """
 Parse local Github issues and generate directory listing

--- a/octohub/contrib/popularity/octohub-list-popularity
+++ b/octohub/contrib/popularity/octohub-list-popularity
@@ -23,6 +23,7 @@ Environment:
     OCTOHUB_LOGLEVEL            Log level debugging sent to stderr
 
 """
+from __future__ import print_function
 
 import os
 import sys

--- a/octohub/contrib/pull-requests/octohub-list-pullrequests
+++ b/octohub/contrib/pull-requests/octohub-list-pullrequests
@@ -23,6 +23,7 @@ Environment:
     OCTOHUB_LOGLEVEL            Log level debugging sent to stderr
 
 """
+from __future__ import print_function
 
 import os
 import sys

--- a/octohub/response.py
+++ b/octohub/response.py
@@ -6,6 +6,7 @@
 # terms of the GNU General Public License as published by the Free Software
 # Foundation; either version 3 of the License, or (at your option) any later
 # version.
+from __future__ import print_function
 
 import re
 

--- a/octohub/utils.py
+++ b/octohub/utils.py
@@ -6,6 +6,7 @@
 # terms of the GNU General Public License as published by the Free Software
 # Foundation; either version 3 of the License, or (at your option) any later
 # version.
+from __future__ import print_function
 
 import os
 import logging


### PR DESCRIPTION
Python 3's print implementation is incompatible with Python 2,
unless it's been imported from the __future__ module.